### PR TITLE
Added vault.hcl jinja2 template and replace static /opt/data/ paths t…

### DIFF
--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -136,7 +136,7 @@
   when:
     - ansible_service_mgr == "systemd"
 
-- name: Generate vault configuration 
+- name: Generate vault configuration
   ansible.builtin.template:
     src: vault.hcl.j2
     dest: "{{ vault_path }}/etc/vault.d/vault.hcl"

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -72,8 +72,8 @@
 - name: Generate TLS key and certificate
   ansible.builtin.command:
     cmd: openssl req -out tls.crt -new -keyout tls.key -newkey rsa:4096 -nodes -sha256 -x509 -subj "/O=HashiCorp/CN=Vault" -days 1095
-    chdir: /opt/vault/tls
-    creates: /opt/vault/tls/tls.key
+    chdir: "{{ vault_data_directory }}/tls/"
+    creates: "{{ vault_data_directory }}/tls/tls.key"
   notify:
     - Restart vault
 
@@ -136,9 +136,9 @@
   when:
     - ansible_service_mgr == "systemd"
 
-- name: Copy vault configuration
-  ansible.builtin.copy:
-    src: vault.hcl
+- name: Generate vault configuration 
+  ansible.builtin.template:
+    src: vault.hcl.j2
     dest: "{{ vault_path }}/etc/vault.d/vault.hcl"
     owner: root
     group: root

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -1,0 +1,47 @@
+# Full configuration options can be found at https://www.vaultproject.io/docs/configuration
+
+ui = true
+
+#mlock = true
+#disable_mlock = true
+
+storage "file" {
+  path = "{{ vault_data_directory }}/data"
+}
+
+#storage "consul" {
+#  address = "127.0.0.1:8500"
+#  path    = "vault"
+#}
+
+# HTTP listener
+#listener "tcp" {
+#  address = "127.0.0.1:8200"
+#  tls_disable = 1
+#}
+
+# HTTPS listener
+listener "tcp" {
+  address       = "0.0.0.0:8200"
+  tls_cert_file = "{{ vault_data_directory }}/tls/tls.crt" 
+  tls_key_file  = "{{ vault_data_directory }}/tls/tls.key"
+}
+
+# Enterprise license_path
+# This will be required for enterprise as of v1.8
+#license_path = "/etc/vault.d/vault.hclic"
+
+# Example AWS KMS auto unseal
+#seal "awskms" {
+#  region = "us-east-1"
+#  kms_key_id = "REPLACE-ME"
+#}
+
+# Example HSM auto unseal
+#seal "pkcs11" {
+#  lib            = "/usr/vault/lib/libCryptoki2_64.so"
+#  slot           = "0"
+#  pin            = "AAAA-BBBB-CCCC-DDDD"
+#  key_label      = "vault-hsm-key"
+#  hmac_key_label = "vault-hsm-hmac-key"
+#}


### PR DESCRIPTION
## Summary
- This will solve issue #15.
- I was not able to get molecule running on my nixos, so I could not test it for the other distributions.
- I successfully deployed it on raspberry pi 4 with 2 GB running Arch Linux (pikvm) with this role
- In order to allow arm as architecture I added it to `vars/main.yml` and defined it in my playbook as `vault_architecture: "arm"` `ansible_architecture: "arm"`
